### PR TITLE
 Static-ify the actor/supervisor interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 Cargo.lock
 
 .idea/
+.vscode/

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -248,23 +248,19 @@ mod tests {
     }
 
 
-    impl<H> Actor<Box<Any + Send>> for MyActor<H>
+    impl<H> Actor<u64> for MyActor<H>
         where H: Send + Spawn + Clone + 'static
     {
-        fn on_message(&mut self, msg: Box<Any + Send>) {
-            if let Some(number) = msg.downcast_ref::<u64>() {
-                if number % 1000 == 0 {
-                    println!("{} got {}", self.id, number);
-                }
-
-                //                if *number == 0 {panic!("zero!")};
-                let new_actor = MyActor::new(self.handle.clone());
-                let actor_ref = actor_of(self.handle.clone(), new_actor);
-                actor_ref.sender.send(Box::new(number + 1));
-                drop(actor_ref);
-            } else {
-                panic!("downcast error");
+        fn on_message(&mut self, msg: u64) {
+            let number = msg;
+            if number % 1000 == 0 {
+                println!("{} got {}", self.id, number);
             }
+
+            //                if *number == 0 {panic!("zero!")};
+            let new_actor = MyActor::new(self.handle.clone());
+            let actor_ref = actor_of(self.handle.clone(), new_actor);
+            actor_ref.sender.send(number + 1);
         }
     }
 
@@ -284,7 +280,7 @@ mod tests {
 
         supervisor_ref.send(SupervisorMessage {
                                 id: "worker child".to_owned(),
-                                msg: Box::new(1000000 as u64) as Box<Any + Send>,
+                                msg: 1000000,
                             });
 
         drop(supervisor_ref);
@@ -298,7 +294,7 @@ mod tests {
 
         let actor = MyActor::new(system.handle());
         let mut actor_ref = actor_of(system.handle(), actor);
-        actor_ref.send(Box::new(0 as u64));
+        actor_ref.send(0 as u64);
         drop(actor_ref);
 
         let _ = system.run();

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,41 +1,38 @@
 use std;
-use std::any::Any;
-use std::panic;
-use std::panic::AssertUnwindSafe;
-
-use chashmap::CHashMap;
 
 use two_lock_queue::{unbounded, Sender, Receiver, TryRecvError};
 
 use futures;
 use futures::future::*;
 
-use futures::{Future, future};
-use fibers::{Executor, ThreadPoolExecutor, Spawn};
+use fibers::Spawn;
 
 use uuid::Uuid;
 
-pub trait Actor: Send {
-    fn on_message(&mut self, msg: Box<Any + Send>);
+pub trait Actor<M: Send>: Send {
+    fn on_message(&mut self, msg: M);
 }
 
-pub trait ActorRef: Clone {
-    fn send(&mut self, msg: Box<Any + Send>);
+pub trait ActorRef<M: Send>: Clone {
+    fn send(&mut self, msg: M);
 }
 
-pub struct Supervisor<H, F>
+pub struct Supervisor<A, H, F, M>
     where H: Send + Spawn + Clone + 'static,
-          F: Send + 'static + Fn(H) -> Box<Actor>
+          F: Send + 'static + Fn(H) -> A,
+          A: Actor<M>,
+          M: Send
 {
-    map: std::collections::HashMap<String, (WorkerRef, ChildSpec<H, F>)>,
-    handle: H,
+    map: std::collections::HashMap<String, (WorkerRef<M>, ChildSpec<A, H, F, M>)>,
 }
 
-impl<H, F> Supervisor<H, F>
+impl<A, H, F, M> Supervisor<A, H, F, M>
     where H: Send + Spawn + Clone + 'static,
-          F: Send + 'static + Fn(H) -> Box<Actor>
+          F: Send + 'static + Fn(H) -> A,
+          A: Actor<M> + 'static,
+          M: Send + 'static
 {
-    pub fn new(handle: H, child_specs: Vec<ChildSpec<H, F>>) -> Supervisor<H, F> {
+    pub fn new(handle: H, child_specs: Vec<ChildSpec<A, H, F, M>>) -> Supervisor<A, H, F, M> {
         let mut map = std::collections::HashMap::new();
 
         for spec in child_specs {
@@ -44,46 +41,55 @@ impl<H, F> Supervisor<H, F>
             map.insert(spec.key.clone(), (actor, spec));
         }
 
-        Supervisor {
-            map: map,
-            handle: handle,
-        }
+        Supervisor { map: map }
     }
 }
 
-impl<H, F> Actor for Supervisor<H, F>
+impl<A, H, F, M> Actor<SupervisorMessage<M>> for Supervisor<A, H, F, M>
     where H: Send + Spawn + Clone + 'static,
-          F: Send + 'static + Fn(H) -> Box<Actor>
+          F: Send + 'static + Fn(H) -> A,
+          A: Actor<M>,
+          M: Send
 {
-    fn on_message(&mut self, msg: Box<Any + Send>) {
-        if let Ok(msg) = msg.downcast::<SupervisorMessage>() {
-            let id = msg.id.clone();
-            println!("got id {}", id);
-            if let Some(val) = self.map.get_mut(&id) {
-                let &mut (ref mut actor, ref childspec) = val;
+    fn on_message(&mut self, msg: SupervisorMessage<M>) {
+        let id = msg.id.clone();
+        println!("got id {}", id);
+        if let Some(val) = self.map.get_mut(&id) {
+            let &mut (ref mut actor, _) = val;
 
-                let msg = msg.msg;
-                actor.send(msg)
+            let msg = msg.msg;
+            actor.send(msg)
 
-//                match result {
-//                    Err(_) => {
-//                        *actor = actor_of(self.handle.clone(),
-//                                          (childspec.start)(self.handle.clone()))
-//                    }
-//                    _ => (),
-//                }
-            }
-        } else {
-            panic!("downcast error");
+            //                match result {
+            //                    Err(_) => {
+            //                        *actor = actor_of(self.handle.clone(),
+            //                                          (childspec.start)(self.handle.clone()))
+            //                    }
+            //                    _ => (),
+            //                }
         }
     }
 }
 
-#[derive(Clone)]
-pub struct WorkerRef {
-    sender: Sender<Box<Any + Send>>,
-    receiver: Receiver<Box<Any + Send>>,
+pub struct WorkerRef<M>
+    where M: Send
+{
+    sender: Sender<M>,
+    receiver: Receiver<M>,
     id: String,
+}
+
+// wtf, why does this work and #[derive(Clone)] not?
+impl<M> Clone for WorkerRef<M>
+    where M: Send
+{
+    fn clone(&self) -> Self {
+        WorkerRef {
+            sender: self.sender.clone(),
+            receiver: self.receiver.clone(),
+            id: self.id.clone(),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -108,28 +114,32 @@ pub enum ActorKind {
 }
 
 #[derive(Clone)]
-pub struct ChildSpec<H, F>
+pub struct ChildSpec<A, H, F, M>
     where H: Send + Spawn + Clone + 'static,
-          F: Send + 'static + Fn(H) -> Box<Actor>
+          F: Send + 'static + Fn(H) -> A,
+          A: Actor<M>,
+          M: Send
 {
     key: String,
     start: F,
     restart: Restart,
     shutdown: Shutdown,
     kind: ActorKind,
-    _ph: std::marker::PhantomData<H>,
+    _ph: std::marker::PhantomData<(H, M)>,
 }
 
-impl<H, F> ChildSpec<H, F>
+impl<A, H, F, M> ChildSpec<A, H, F, M>
     where H: Send + Spawn + Clone + 'static,
-          F: Send + 'static + Fn(H) -> Box<Actor>
+          F: Send + 'static + Fn(H) -> A,
+          A: Actor<M>,
+          M: Send
 {
     pub fn new(key: String,
                start: F,
                restart: Restart,
                shutdown: Shutdown,
                kind: ActorKind)
-               -> ChildSpec<H, F> {
+               -> ChildSpec<A, H, F, M> {
         ChildSpec {
             key: key,
             start: start,
@@ -141,23 +151,27 @@ impl<H, F> ChildSpec<H, F>
     }
 }
 
-struct SupervisorMessage {
+pub struct SupervisorMessage<M> {
     id: String,
-    msg: Box<Any + Send>,
+    msg: M,
 }
 
-impl ActorRef for WorkerRef {
-    fn send(&mut self, msg: Box<Any + Send>) {
+impl<M> ActorRef<M> for WorkerRef<M>
+    where M: Send
+{
+    fn send(&mut self, msg: M) {
         self.sender.send(msg).unwrap();
     }
 }
 
-pub fn supervised_actor_of<H, F>(exec: H,
-                                 mut actor: Box<Actor>,
-                                 policy: ChildSpec<H, F>)
-                                 -> WorkerRef
+pub fn supervised_actor_of<A, H, F, M>(exec: H,
+                                       mut actor: A,
+                                       _: ChildSpec<A, H, F, M>)
+                                       -> WorkerRef<M>
     where H: Send + Spawn + Clone + 'static,
-          F: Send + 'static + Fn(H) -> Box<Actor>
+          F: Send + 'static + Fn(H) -> A,
+          A: Actor<M> + 'static,
+          M: Send + 'static
 {
     let (sender, receiver) = unbounded();
     let recvr = receiver.clone();
@@ -181,8 +195,10 @@ pub fn supervised_actor_of<H, F>(exec: H,
 }
 
 
-pub fn actor_of<H>(exec: H, mut actor: Box<Actor>) -> WorkerRef
-    where H: Send + Spawn + Clone + 'static
+pub fn actor_of<A, H, M>(exec: H, mut actor: A) -> WorkerRef<M>
+    where H: Send + Spawn + Clone + 'static,
+          M: Send + 'static,
+          A: Actor<M> + 'static
 {
     let (sender, receiver) = unbounded();
     let recvr = receiver.clone();
@@ -209,6 +225,10 @@ pub fn actor_of<H>(exec: H, mut actor: Box<Actor>) -> WorkerRef
 mod tests {
     use super::*;
 
+    use std::any::Any;
+
+    use fibers::{Executor, ThreadPoolExecutor};
+
     struct MyActor<H>
         where H: Send + Spawn + Clone + 'static
     {
@@ -228,7 +248,7 @@ mod tests {
     }
 
 
-    impl<H> Actor for MyActor<H>
+    impl<H> Actor<Box<Any + Send>> for MyActor<H>
         where H: Send + Spawn + Clone + 'static
     {
         fn on_message(&mut self, msg: Box<Any + Send>) {
@@ -238,7 +258,7 @@ mod tests {
                 }
 
                 //                if *number == 0 {panic!("zero!")};
-                let new_actor = Box::new(MyActor::new(self.handle.clone())) as Box<Actor>;
+                let new_actor = MyActor::new(self.handle.clone());
                 let actor_ref = actor_of(self.handle.clone(), new_actor);
                 actor_ref.sender.send(Box::new(number + 1));
                 drop(actor_ref);
@@ -254,35 +274,34 @@ mod tests {
         let handle = system.handle();
 
         let child_spec = ChildSpec::new("worker child".to_owned(),
-                                        move |handle| Box::new(MyActor::new(handle)) as Box<Actor>,
+                                        move |handle| MyActor::new(handle),
                                         Restart::Temporary,
                                         Shutdown::Eventually,
                                         ActorKind::Worker);
 
-        let mut supervisor_ref =
-            actor_of(handle.clone(),
-                     Box::new(Supervisor::new(handle.clone(), vec![child_spec])) as Box<Actor>);
+        let mut supervisor_ref = actor_of(handle.clone(),
+                                          Supervisor::new(handle.clone(), vec![child_spec]));
 
-        supervisor_ref.send(Box::new(SupervisorMessage {
-            id: "worker child".to_owned(),
-            msg: Box::new(1000000 as u64),
-        }));
-
+        supervisor_ref.send(SupervisorMessage {
+                                id: "worker child".to_owned(),
+                                msg: Box::new(1000000 as u64) as Box<Any + Send>,
+                            });
 
         drop(supervisor_ref);
 
         let _ = system.run();
     }
 
-        #[test]
-        fn test_name() {
-            let system = ThreadPoolExecutor::with_thread_count(2).unwrap();
+    #[test]
+    fn test_name() {
+        let system = ThreadPoolExecutor::with_thread_count(2).unwrap();
 
-            let actor = MyActor::new(system.handle());
-            let mut actor_ref = actor_of(system.handle(), Box::new(actor));
-            actor_ref.send(Box::new(0 as u64));
-            drop(actor_ref);
+        let actor = MyActor::new(system.handle());
+        let mut actor_ref = actor_of(system.handle(), actor);
+        actor_ref.send(Box::new(0 as u64));
+        drop(actor_ref);
 
-            let _ = system.run();
-        }
+        let _ = system.run();
+    }
 }
+


### PR DESCRIPTION
Makes the api a lot cleaner on the calling end at the cost of some gnarly type signatures.
Still not 100% sure this is the best way to go about it, but at least it gets rid of most of the boxing.

Also added a gitignore for `.vscode/`.